### PR TITLE
fix HTML link

### DIFF
--- a/content/pages/committers.md
+++ b/content/pages/committers.md
@@ -210,7 +210,7 @@ This information has moved [here](mailing-list-moderation.html)
   - faithful implementation of standards
   - security as a mandatory feature
 
-A non-official <a href="http://theapacheway.com/" target=_blank">The Apache Way</a> website is available.</p>
+A non-official <a href="http://theapacheway.com/" target="_blank">The Apache Way</a> website is available.</p>
 
 <h4 id="projectindependence">Are Apache projects really independent?<a class="headerlink" href="#projectindependence" title="Permanent link">&para;</a></h4>
 


### PR DESCRIPTION
The link was not formatted correctly and thus could not be displayed correctly.

This PR fixes the HTML.