### PR TITLE
Removed the  copyright of Github from Notice

### DIFF
--- a/content/pages/licensing-howto.md
+++ b/content/pages/licensing-howto.md
@@ -110,5 +110,4 @@ Copyright 2009 - 2013 Adobe Systems Incorporated. All Rights Reserved.
 The ping sound effect (ping.mp3) in 
 examples/mxroyale/tourdeflexmodules/src/mx/effects/assets
 was created by CameronMusic. (http://www.freesound.org/people/cameronmusic/sounds/138420/)
-© 2020 GitHub, Inc.
 ```


### PR DESCRIPTION
I just checked the [Notice file of Apache Royale](https://github.com/apache/royale-asjs/blob/develop/NOTICE),  it doesn't have copyright information of Github.
