### PR TITLE
Update menu.html

### DIFF
--- a/content/theme/templates/menu.html
+++ b/content/theme/templates/menu.html
@@ -28,6 +28,7 @@
                 <li><a href="/machines.html" target="_blank" >Machines and Fingerprints</a></li>
                 <li><a href="https://blocky.apache.org" target="_blank" >Blocky</a></li>
 		<li><a href="https://app.datadoghq.com/account/login?next=%2Finfrastructure" target="_blank" >DataDog</a></li>
+		<li><a href="https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/apache-monitoring-integration/" target="_blank" >New Relic</a></li>
 		<li><a href="https://whimsy.apache.org/roster/committer/" target="_blank" >Committer Search</a></li>
 		
                 </ul>


### PR DESCRIPTION
Hi Team,
We have many users on our New Relic platform who are using Apache and would like to instrument it. We’d love to provide a smooth experience for Apache users who need to use commercial monitoring solutions. Please see our documentation here "https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/apache-monitoring-integration/".

Please consider adding a link for your direct users to provide an option for New Relic. We propose the content submitted in this PR.