### PR TITLE
Remove unneeded paragraph tags

### DIFF
--- a/content/pages/mailing-list-moderation.md
+++ b/content/pages/mailing-list-moderation.md
@@ -29,7 +29,8 @@ At the same time, as communities grow, the need for more specialized mailing lis
 **WARNING**: Creating a user email list can harm a project community if the developers don't pay attention to their users and reply to their emails. One would expect a well-behaving user community to reply to one another in a civil, adult manner that is focused on whatever the list was created for, but it can take time for a community to learn and take to heart such good behavior.
 
 <h3 id="mailing-list-moderators">How do I request changes for moderators?<a class="headerlink" href="#mailing-list-moderators" title="Permanent link">&para;</a></h3>
-<p>File an INFRA Jira ticket or ask your PMC to send a request to the `apmail@apache.org` alias. If you have access to apmail, you can just change the list of subscribers
+
+File an INFRA Jira ticket or ask your PMC to send a request to the `apmail@apache.org` alias. If you have access to apmail, you can just change the list of subscribers
 to list/mod. For example, for the `mod_perl` developers' list that is in `~apmail/lists/perl.apache.org/dev/mod/`, use 
 `ezmlm-list`, `>ezmlm-sub` and `ezmlm-unsub`.
 
@@ -103,7 +104,7 @@ This is already in the correct form for use in the 'deny' subscription request, 
 badposter=menace.com
 ```
 
-If this address contains random alphanumerics then it is probably a short-lived address, in which case there is no point trying to use the deny list.</p>
+If this address contains random alphanumerics then it is probably a short-lived address, in which case there is no point trying to use the deny list.
 
 
 <h3 id="allowing_posts">Allowing posts from non-subscribers<a class="headerlink" href="#allowing_posts" title="Permanent link">&para;</a></h3>


### PR DESCRIPTION
Remove the unneeded paragraph tags. The following section doesn't display the markdown characters correctly: https://infra.apache.org/mailing-list-moderation.html#mailing-list-moderators

I think this has to do because of the mixing of HTML and markdown on the same line. Since I see no real use case for inserting a `<p>` tag, just remove it.

I also removed the rogue `</p>` closing tag, which doesn't have a matching opening tag.

I tried testing this locally using the instructions in the README, but that didn't work for me, see the log:

```bash
[rlenferink@fedora infrastructure-website]$ virtualenv venv
created virtual environment CPython3.11.1.final.0-64 in 111ms
  creator CPython3Posix(dest=/home/rlenferink/workspace/asf/infra/infrastructure-website/venv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(extra_search_dir=/usr/share/python-wheels,download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/rlenferink/.local/share/virtualenv)
    added seed packages: pip==22.2.2, setuptools==62.6.0, wheel==0.37.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
[rlenferink@fedora infrastructure-website]$ source venv/bin/activate
(venv) [rlenferink@fedora infrastructure-website]$ pip install -r requirements.txt 
Collecting pelican
  Using cached pelican-4.8.0-py3-none-any.whl (1.4 MB)
Collecting beautifulsoup4
  Using cached beautifulsoup4-4.11.2-py3-none-any.whl (129 kB)
Collecting requests
  Using cached requests-2.28.2-py3-none-any.whl (62 kB)
Collecting blinker>=1.4
  Using cached blinker-1.5-py2.py3-none-any.whl (12 kB)
Collecting docutils>=0.16
  Using cached docutils-0.19-py3-none-any.whl (570 kB)
Collecting feedgenerator>=1.9
  Using cached feedgenerator-2.0.0-py3-none-any.whl (21 kB)
Collecting jinja2>=2.7
  Using cached Jinja2-3.1.2-py3-none-any.whl (133 kB)
Collecting pygments>=2.6
  Using cached Pygments-2.14.0-py3-none-any.whl (1.1 MB)
Collecting python-dateutil>=2.8
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pytz>=2020.1
  Using cached pytz-2022.7.1-py2.py3-none-any.whl (499 kB)
Collecting rich>=10.1
  Using cached rich-13.3.2-py3-none-any.whl (238 kB)
Collecting unidecode>=1.1
  Using cached Unidecode-1.3.6-py3-none-any.whl (235 kB)
Collecting soupsieve>1.2
  Using cached soupsieve-2.4-py3-none-any.whl (37 kB)
Collecting charset-normalizer<4,>=2
  Using cached charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (197 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.4-py3-none-any.whl (61 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.14-py2.py3-none-any.whl (140 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2022.12.7-py3-none-any.whl (155 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (27 kB)
Collecting six>=1.5
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting markdown-it-py<3.0.0,>=2.2.0
  Using cached markdown_it_py-2.2.0-py3-none-any.whl (84 kB)
Collecting mdurl~=0.1
  Using cached mdurl-0.1.2-py3-none-any.whl (10.0 kB)
Installing collected packages: pytz, urllib3, unidecode, soupsieve, six, pygments, mdurl, MarkupSafe, idna, feedgenerator, docutils, charset-normalizer, certifi, blinker, requests, python-dateutil, markdown-it-py, jinja2, beautifulsoup4, rich, pelican
Successfully installed MarkupSafe-2.1.2 beautifulsoup4-4.11.2 blinker-1.5 certifi-2022.12.7 charset-normalizer-3.1.0 docutils-0.19 feedgenerator-2.0.0 idna-3.4 jinja2-3.1.2 markdown-it-py-2.2.0 mdurl-0.1.2 pelican-4.8.0 pygments-2.14.0 python-dateutil-2.8.2 pytz-2022.7.1 requests-2.28.2 rich-13.3.2 six-1.16.0 soupsieve-2.4 unidecode-1.3.6 urllib3-1.26.14

[notice] A new release of pip available: 22.2.2 -> 23.0.1
[notice] To update, run: pip install --upgrade pip
(venv) [rlenferink@fedora infrastructure-website]$ pelican -t theme
[13:50:10] CRITICAL Exception: Could not find the theme theme                                                                                                                                                                  __init__.py:566
```

The `pelican -t theme` step seems to fail.