### PR TITLE
Name search section moved to apache.org

### DIFF
--- a/content/pages/project-names.md
+++ b/content/pages/project-names.md
@@ -8,19 +8,11 @@ These are general guidelines for considering new names for podlings undergoing I
 
 <h3 id="basic-name-search-considerations">Basic Name Search Considerations<a class="headerlink" href="#basic-name-search-considerations" title="Permanent link">&para;</a></h3>
 
-  - "Apache" is our main trademark, or "house mark", for our overall software development process. All Apache projects and podlings share it.
-  - All top level projects (TLPs) must use the format _Apache Foo_ for their branding. However, people in informal conversation will refer to your project as just "Foo", so choose the name carefully.
-  - Use internet search tools to be sure that there is no "similar" product, i.e. software for a specific purpose.
-  - When people conduct an internet search after hearing about an ASF project, they will use some technical terms and a name. We want to appear near the top of the search results and not get confused with some other project in the same technical space.
-  - Avoiding search-results confusion is important for another reason. Apache projects are often very quickly highly ranked. An Apache project with a similar name to another application in the same technical space may quickly come to dominate searches in that space. If someone else holds a related trademark, this may lead to a legal dispute. As a non-profit organization, the ASF and Apache projects have no business conflicting with an existing trademark for software products or related services.
-  - Even if a product name cannot be found via a search, if you are aware that it, or one very like it, is in use for a similar product then we cannot use it.
-  - You may want to choose a name that is easy to remember, is not too long, and is not difficult to spell.
-  - Be culturally sensitive and avoid names that might offend.
-  - Consider using functional names, especially for products of existing projects, e.g. for an "Apache Foo" project, the product name "Apache Foo Pipelines".
-  - Be good citizens. Do unto others as you would expect that they should do unto you. For example, treat the product names of others with respect: do not try a twist that is close to the name of a similar product.
-  - Choose a sensible name early in the product's development, before you develop mailing lists, package names, logos, and other marketing collateral. Better to spend time now - your project will not want to change its product's name later.
-  - See this as an important marketing opportunity, rather than a bother.
-  - By carefully validating the uniqueness of our product and project names and clearly establishing first use in the field, we reduce the chances of future confusion.
+This content has moved to
+<a href="https://www.apache.org/foundation/marks/pmcs.html" target="_blank">
+the trademarks section
+</a>
+of the main apache.org website.
 
 <h3 id="other-trademark-tips">Trademark Tips<a class="headerlink" href="#other-trademark-tips" title="Permanent link">&para;</a></h3>
 


### PR DESCRIPTION
The "Basic Name Search Considerations" section has been copied to https://www.apache.org/foundation/marks/pmcs.html (from [this commit](https://github.com/apache/www-site/commit/e9aec4ea9182a280c29ada57696a7f5c62dba657)), I think it should not be duplicated to avoid inconsistencies, and instead pointed to from this website.