### PR TITLE
Update new-committers-guide.md

### DIFF
--- a/content/pages/new-committers-guide.md
+++ b/content/pages/new-committers-guide.md
@@ -37,20 +37,19 @@ If you are not yet a committer, but would like to become one, review:
 
 <h3 id="the-committers-way">The Committer's Way<a class="headerlink" href="#the-committers-way" title="Permanent link">&para;</a></h3>
 
-As a committer, you have access to a specific Apache project's repository so you can create and edit source code files, not just read them.. Instead of having to create and submit a patch which other committers would have to review and approve, you can now create a local patch and commit it yourself; you can also review and commit patches that other project contributors and committers create. Your patches can still be reviewed by your fellow committers.
+As a committer, you have access to a specific Apache project's repository so you can create and edit source code files, not just read them. Instead of having to create and submit a patch which other committers would have to review and approve, you can now create a local patch and commit it yourself; you can also review and commit patches that other project contributors and committers create. Your patches can still be reviewed by your fellow committers.
 
 Some projects use **RTC** (Review then Commit) rather than **CTR** (Commit then Review). Check which pattern your project uses, and then follow it.
 
-Take more care than you may have done before when working on the code, since you  can now change things directly, without review. Make sure you understand how your project's committers work and coordinate with each other. Ask your project PMC, or any active committer on the project, for guidance if there are things you are not sure about. In general. the more visible and engaged you are in the project, the more fun you will have and the more access you will have to advice and feedback.
+Take more care than you may have done before when working on the code, since you  can now change things directly, without review. Make sure you understand how your project's committers work and coordinate with each other. Ask your project PMC, or any active committer on the project, for guidance if there are things you are not sure about. In general, the more visible and engaged you are in the project, the more fun you will have and the more access you will have to advice and feedback.
 
 <h3 id="submitting-your-individual-contributor-license-agreement-icla">Submitting your Individual Contributor License Agreement (ICLA)</h3>
 
-If you are a brand-new committer, you must complete and submit an <a href="https://www.apache.org/licenses/#clas" target="_blank">Individual Contributor License Agreement</a> (ICLA) before the ASF can active your committer account. Note that an account can only be created if a PMC (or Incubator podling) has invited you. The ICLA is a formal contract that declares the terms under which you will contribute intellectual property to the ASF. Note that the ICLA does <strong>not</strong> assign copyright to the ASF; you retain copyright to your own work. However it does grant the ASF sufficient rights to release any work you submit under the Apache license.</p>
+If you are a brand-new committer, you must complete and submit an <a href="https://www.apache.org/licenses/#contributor-license-agreements" target="_blank">Individual Contributor License Agreement</a> (ICLA) before the ASF can activate your committer account. Note that an account can only be created if a PMC (or Incubator podling) has invited you. The ICLA is a formal contract that declares the terms under which you will contribute intellectual property to the ASF. Note that the ICLA does <strong>not</strong> assign copyright to the ASF; you retain copyright to your own work. However it does grant the ASF sufficient rights to release any work you submit under the Apache license.</p>
 
-  - Choose an Apache ID before submitting your ICLA. Also select an alternative, in case the ID you want is unsuitable or already taken. Your ID must consist of at least three lower-case alphanumeric characters, starting with a letter. (<a href="https://home.apache.org/committer-index.html" target="_blank">This list</a> shows the IDs that are already taken).
+  - Choose an Apache ID before submitting your ICLA. Also select an alternative, in case the ID you want is unsuitable or already taken. Your ID must consist of at least three lower-case alphanumeric characters, starting with a letter. (<a href="https://home.apache.org/committer-index.html" target="_blank">This list</a> shows the IDs that are already taken.)
   - Identify your project (PMC or incubator podling).
-  - **IMPORTANT**: you may need to hold discussions with your employer before signing the ICLA, since your employer may have rights to the coding 
-work you do, even outside of your employment. Your employer might even need to provide a <a href="https://www.apache.org/licenses/#clas" target="_blank">Corporate CLA</a> - determining that is your responsibility. Make sure that you keep up-to-date with this requirement.
+  - **IMPORTANT**: you may need to hold discussions with your employer before signing the ICLA, since your employer may have rights to the coding work you do, even outside of your employment. Your employer might even need to provide a <a href="https://www.apache.org/licenses/#contributor-license-agreements" target="_blank">Corporate CLA</a> - determining that is your responsibility. Make sure that you keep up-to-date with this requirement.
   - Read and understand the agreements ICLA specifies and strive to meet the standards expected. Correct title to code sources is of great importance to ASF and it must be to you, too.
   - Make sure that any code you contribute is original work, and that you publicly contribute it to the ASF. In the case of any doubt (or when a contribution has a complex history) please consult your project PMC before committing it.
 
@@ -60,15 +59,15 @@ For details on how to submit your ICLA, please see <a href="https://www.apache.o
 
 <h3 id="acceptance-of-your-icla">Acceptance of your ICLA<a class="headerlink" href="#acceptance-of-your-icla" title="Permanent link">&para;</a></h3>
 
-After the ASL Secretary records your ICLA, your PMC can submit your requested ID for activation. The acceptance process may take some time. The ASF will inform you and your PMC chair when the process is complete. This quiet lull is a good time to familiarize yourself with the Apache Software Foundation in general. Browse the <a href="https://www.apache.org/dev/" target="_blank">developer guides and information</a>, material about the ASF <a href="https://infra.apache.org/">infrastructure</a>, and the <a href="https://www.apache.org/foundation/" target="_blank">Foundation website</a>. We update the websites regularly.
+After the ASF Secretary records your ICLA, your PMC can submit your requested ID for activation. The acceptance process may take some time. The ASF will inform you and your PMC chair when the process is complete. This quiet lull is a good time to familiarize yourself with the Apache Software Foundation in general. Browse the <a href="https://www.apache.org/dev/" target="_blank">developer guides and information</a>, material about the ASF <a href="https://infra.apache.org/" target="_blank">infrastructure</a>, and the <a href="https://www.apache.org/foundation/" target="_blank">Foundation website</a>. We update the websites regularly.
 
-You will also need to familiarize yourself with some Apache policies and procedures. You have probably picked up a lot of this by osmosis already, and your fellow committers and PMC members on your project's dev@ mailing list are the first place to ask questions.
+You will also need to familiarize yourself with some Apache policies and procedures. You have probably picked up a lot of this by osmosis already, and your fellow committers and PMC members on your project's `dev@` mailing list are the first place to ask questions.
 
 Key Committer resources:
 
   - <a href="https://www.apache.org/dev/index.html" target="_blank">ASF Developer Guides &amp; Resources</a> contains pointers to the most important information
-  - the <a href="https://www.apache.org/foundation/how-it-works.html">ASF How it works</a> document
-  - the <a href="https://incubator.apache.org/learn/" target="_blank">Incubator Learn</a> pages
+  - the <a href="https://www.apache.org/foundation/how-it-works.html" target="_blank">ASF How it works</a> document
+  - the <a href="https://training.apache.org/" target="_blank">Apache Training (Incubating)</a> pages
   - the <a href="https://www.apache.org/foundation/bylaws.html" target="_blank">ASF Bylaws</a>
 
 <h3 id="apache-committer-account-creation">Apache Committer account creation<a class="headerlink" href="#apache-committer-account-creation" title="Permanent link">&para;</a></h3>
@@ -79,9 +78,9 @@ You will receive an email when your account has been created. (This may take a w
 
 Read the <a href="https://infra.apache.org/committer-email.html" target="_blank">guide</a> to connecting to and working with your Apache email inbox.
 
-Record any email aliases you use in the 'asf-altEmail' field in your LDAP record. You can do this through the the <a href="https://id.apache.org/" target="_blank">self-serve application</a>. The system uses the address in the LDAP 'mail' field to forward email sent to your `@apache.org` address. This field must have at least one entry, which must not be your `@apache.org` address.
+Record any email aliases you use in the `asf-altEmail` field in your LDAP record. You can do this through the the <a href="https://id.apache.org/" target="_blank">self-serve application</a>. The system uses the address in the LDAP `mail` field to forward email sent to your `@apache.org` address. This field must have at least one entry, which must not be your `@apache.org` address.
 
-The 'asf-altEmail' field is used to validate subscription requests and correlate subscriptions. (There is no need to duplicate 'mail' entries in `asf-altEmail`.)
+The `asf-altEmail` field is used to validate subscription requests and correlate subscriptions. (There is no need to duplicate `mail` entries in `asf-altEmail`.)
 
 **Note**: Please read [Dealing with spam in your ASF email account](spam-reporting.html) and **do not** flag valid ASF-related email as spam.
 
@@ -99,17 +98,17 @@ To use GitHub, you need to integrate your GitHub ID with your Apache account, so
 
 1. Verify you have a GitHub ID enabled with <a href="https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/" target="_blank">two factor authentication (2FA)</a>.
 2. Merge your Apache and GitHub accounts using <a href="https://gitbox.apache.org/boxer/" target="_blank">Boxer</a>, the Apache account linking utility for GitHub. Follow the steps outlined in the linking process. You should see three green checks in Boxer when your account has been fully linked.
-3. After about two to five minutes, you should have access to your project's repositories on GitHub. 
+3. After about two to five minutes, you should have access to your project's repositories on GitHub.
 
 #### Using Gitbox
 To connect to Git repositories through Gitbox, visit <a href="https://gitbox.apache.org" target="_blank">Gitbox</a> and follow the onscreen instructions.
 
 ### Your first commit to a Git repository
-If your project has a page for its developers and committers on its website, add your name and information to it. This is a great way to make your first commit, and helps your team get to know you. 
+If your project has a page for its developers and committers on its website, add your name and information to it. This is a great way to make your first commit, and helps your team get to know you.
 
-It also serves another purpose: you will learn how to add documentation to your project's website and the technology used to build it. Documentation is vital, and being able to improve the project's web site is a skill that you will need. If your project has not documented how to rebuild the website, then ask on your dev mailing list and use the answer to create a document describing how to do that. It will be gratefully received! 
+It also serves another purpose: you will learn how to add documentation to your project's website and the technology used to build it. Documentation is vital, and being able to improve the project's web site is a skill that you will need. If your project has not documented how to rebuild the website, then ask on your `dev@` mailing list and use the answer to create a document describing how to do that. It will be gratefully received!
 
-Every team has a lot of "tribal" knowledge" that team members hold in their heads or in private notes, but that the whole team needs to know in order to function well and survive a disaster like a key team member suddenly becoming unavailable. You can help migrate tribal knowledge into the documentation, by noting where you have to ask a team member for guidance that you cannot find in the docs.
+Every team has a lot of "tribal knowledge" that team members hold in their heads or in private notes, but that the whole team needs to know in order to function well and survive a disaster like a key team member suddenly becoming unavailable. You can help migrate tribal knowledge into the documentation, by noting where you have to ask a team member for guidance that you cannot find in the docs.
 
 <h3 id="set-up-security-and-pgp-keys">Set Up Security And PGP Keys<a class="headerlink" href="#set-up-security-and-pgp-keys" title="Permanent link">&para;</a></h3>
 
@@ -119,7 +118,7 @@ Security is vital and Apache pays great attention to it. Remember that at all ti
 
 Upload the public key to a public key server, for example the <a href="https://pgp.mit.edu/" target="_blank">MIT PGP Public Key Server</a>. Then add your keys' primary fingerprints to <a href="https://id.apache.org/" target="_blank">your LDAP profile</a>. The system adds your key to the <a href="https://home.apache.org/keys/" target="_blank">individual and per-project pre-fetched KEYS files</a>, and lets automated tools encrypt communications to you.
 
-Start to build up a good web of trust now before you need to use it in earnest. Be prepared to exchange key information at face-to-face events where ASF folks may be present. The best practice is to insist on identification before signing another person's key. See the <a href="release-signing.html#link-into-wot">Apache release signing guide</a>.
+Start to build up a good web of trust now before you need to use it in earnest. Be prepared to exchange key information at face-to-face events where ASF folks may be present. The best practice is to insist on identification before signing another person's key. See the <a href="release-signing.html#link-into-wot" target="_blank">Apache release signing guide</a>.
 
 <h3 id="committer-resources">Committer Resources<a class="headerlink" href="#committer-resources" title="Permanent link">&para;</a></h3>
 
@@ -133,7 +132,7 @@ Once you have checked out this module, read all the documents contained in the `
 
 <h3 id="get-to-know-the-apache-community">Get to know the Apache community<a class="headerlink" href="#get-to-know-the-apache-community" title="Permanent link">&para;</a></h3>
 
-Taking part in the community makes Apache fun. The <a href="https://community.apache.org/" target="_blank">Community Development project</a>  has a central mailing list for topics that cut across PMC boundaries. Discussions of all kinds are on topic as long as the matter isn't sensitive or confidential.
+Taking part in the community makes Apache fun. The <a href="https://community.apache.org/" target="_blank">Community Development project</a>  has a central mailing list for topics that cut across PMC boundaries. Discussions of all kinds are on topic as long as the matter is not sensitive or confidential.
 
 <h4 id="mailing-lists">Join email lists<a class="headerlink" href="#mailing-lists" title="Permanent link">&para;</a></h4>
 
@@ -148,13 +147,13 @@ Instructions for joining and leaving lists, and a browsable list of Apache maili
 
 Join your project's `commits@` and `dev@` mailing lists to keep up with project activity. Answering questions on `users@` is also very much appreciated and noticed by your PMC.
 
-Each committer has a responsibility to monitor changes made for potential issues, both coding and legal. If you spot any potential issues in a commit, the right course of action is to post a reply (to the email) raising your concerns to the dev list. In extreme situations, it may be necessary to veto (-1) a commit, but this is an extreme sanction and rarely warranted. Read the <a href="https://www.apache.org/foundation/voting.html">voting guidelines</a> before deploying a veto.
+Each committer has a responsibility to monitor changes made for potential issues, both coding and legal. If you spot any potential issues in a commit, the right course of action is to post a reply (to the email) raising your concerns to the `dev@` list. In extreme situations, it may be necessary to veto (-1) a commit, but this is an extreme sanction and rarely warranted. Read the <a href="https://www.apache.org/foundation/voting.html" target="_blank">voting guidelines</a> before deploying a veto.
 
 Do not be surprised if your first commit has a delayed diff email. It needs to go through the human moderators.
 
 <h3 id="attending-apachecon">Attending ApacheCon<a class="headerlink" href="#attending-apachecon" title="Permanent link">&para;</a></h3>
 
-If you don't have one already, make a note in your diary about the next <a href="https://www.apachecon.com/">ApacheCon</a>. This is a great opportunity to meet other Apache folks, hack code and learn about great new open source projects. Watch the lists as the conference dates approach for details about special deals for committers and opportunities to speak.
+If you do not have one already, make a note in your diary about the next <a href="https://www.apachecon.com/" target="_blank">ApacheCon</a>. This is a great opportunity to meet other Apache folks, hack code and learn about great new open source projects. Watch the lists as the conference dates approach for details about special deals for committers and opportunities to speak.
 
 <h3 id="personal-web-space">Personal web space<a class="headerlink" href="#personal-web-space" title="Permanent link">&para;</a></h3>
 
@@ -169,14 +168,13 @@ Please be aware that Apache Software Foundation committers are targets for ident
 Leaking your access to Apache can have very destructive consequences. **Never** disclose your ASF password to anyone.
 
 The Apache Infrastructure team is clueful about DNS maintenance: do **not** trust any redirection by IP address. Your access to Apache will be through the
-machines serving the `svn.apache.org` domain. The ssh/ssl fingerprints of machines are listed on the <a href="/machines" target="_blank">machines</a> page, and our <a href="https://infra.apache.org/version-control.html#cert">SVN server fingerprints</a> are also listed.
+machines serving the `svn.apache.org` domain. The SSH/SSL fingerprints of machines are listed on the <a href="/machines" target="_blank">machines</a> page, and our <a href="https://infra.apache.org/version-control.html#cert" target="_blank">SVN server fingerprints</a> are also listed.
 
 Please use caution. Do not hesitate to ask if you have doubts: post a question to infrastructure before taking any action.
 
 <h3 id="share-your-wisdom">Share your wisdom<a class="headerlink" href="#share-your-wisdom" title="Permanent link">&para;</a></h3>
 
-Please help to improve this document (see <a href="https://www.apache.org/dev/infra-site.html" target="_blank">guidelines</a> for 
-updating this website).
+Please help to improve this document (see <a href="https://www.apache.org/dev/infra-site.html" target="_blank">guidelines</a> for updating <a href="https://github.com/apache/infrastructure-website" target="_blank">this website</a>).
 
 [Volunteer](infra-volunteer.html) if you would like to help the Infrastructure team keep the good ship ASF afloat.
 


### PR DESCRIPTION
Minor nits and unification of style, noticed while studying the document:

- Fix typos, markdown, letter casing.
- Use `target="_blank"` to `href`s more frequently to make it easier to read the guide.
- Fix broken links.
- Remove trailing whitespace.