### PR TITLE
Update repository-faq.md

### DIFF
--- a/content/pages/repository-faq.md
+++ b/content/pages/repository-faq.md
@@ -2,14 +2,18 @@ Title: Apache Maven repositories
 
 <h2 id="basic">Basic information<a class="headerlink" href="#basic" title="Permanent link">&para;</a></h2>
 
-The main snapshot and release Maven repositories for Apache are at <a href="https://repository.apache.org" target="_blank">https://repository.apache.org</a>. The repository also proxies Apache's legacy repositories.
+**Reminder**: Apache projects **must** release all software packages through the ASF distribution system. See [Release distribution policy](release-distribution.html) for more details.
+
+Projects can also opt to release artifacts publicly through the [Maven Central Repository](https://maven.apache.org/repository/index.html), which is primarily for Java artifacts.
+
+The ASF maintains internal snapshot and release Maven repositories at <a href="https://repository.apache.org" target="_blank">https://repository.apache.org</a>. The repository also proxies Apache's legacy repositories. **Note**: these repos are intended for internal ASF project use, not for public distribution of artifacts. Except in the rare situation when a project needs external testing of preproduction artifacts, **do not** provide download links to 'repository.apache.org' assets to users external to The ASF.
 
 If your Apache project would like to use `repository.apache.org`, see [Publishing Maven Releases](publishing-maven-artifacts.html).
 
   - Use the `New` repo and staging process to help prevent accidental releases and ensure that releases meet Apache standards.
   - Subscribe to the repository mailing list via `repository-subscribe@apache.org` for questions, complaints and ideas.
 
-If you're a user looking for Apache artifacts from a Maven repository, all releases are synced to <a href="https://repo1.maven.org/maven2" target="_blank">Central</a> and snapshots are available here:
+If you're a user looking for Apache artifacts from a Maven repository, all releases are synced to <a href="https://repo1.maven.org/maven2" target="_blank">Maven Central</a> and snapshots are available here:
 <a href="https://repository.apache.org/snapshots/" target="_blank">http://repository.apache.org/snapshots/</a>.
 
 <h2 id="faq">FAQs about the ASF Jar repositories<a class="headerlink" href="#faq" title="Permanent link">&para;</a></h2>
@@ -21,10 +25,6 @@ You can with the <em>snapshot</em> repositories, but you cannot with the <em>rel
 <h4 id="revolutioncode">Can I release a research branch to the repositories?<a class="headerlink" href="#revolutioncode" title="Permanent link">&para;</a></h4>
 
 As long as your project's PMC is happy with the release, you can release a research branch to the snapshot repository; otherwise you should just release in your `home.apache.org` personal space.
-
-<h4 id="repodotapache">What is 'repository.apache.org'?<a class="headerlink" href="#repodotapache" title="Permanent link">&para;</a></h4>
-
-Apache operates a repository manager at <a href="https://repository.apache.org/" target="_blank">https://repository.apache.org/</a>. Apache projects can use it to deploying snapshots, releases, or both. See the [Publishing Maven Releases](publishing-maven-artifacts.html) guide for more details.
 
 <h4 id="rsyncs">How do rsyncs happen?<a class="headerlink" href="#rsyncs" title="Permanent link">&para;</a></h4>
 

--- a/content/pages/repository-faq.md
+++ b/content/pages/repository-faq.md
@@ -4,9 +4,9 @@ Title: Apache Maven repositories
 
 **Reminder**: Apache projects **must** release all software packages through the ASF distribution system. See [Release distribution policy](release-distribution.html) for more details.
 
-Projects can also opt to release artifacts publicly through the [Maven Central Repository](https://maven.apache.org/repository/index.html), which is primarily for Java artifacts.
+The ASF maintains internal snapshot and release Maven repositories at <a href="https://repository.apache.org" target="_blank">https://repository.apache.org</a>. The repository also proxies Apache's legacy repositories. 
 
-The ASF maintains internal snapshot and release Maven repositories at <a href="https://repository.apache.org" target="_blank">https://repository.apache.org</a>. The repository also proxies Apache's legacy repositories. **Note**: these repos are intended for internal ASF project use, not for public distribution of artifacts. Except in the rare situation when a project needs external testing of preproduction artifacts, **do not** provide download links to 'repository.apache.org' assets to users external to The ASF.
+**Note**: these repos are intended for internal ASF project use, not for public distribution of artifacts. Except in the rare situation when a project needs external testing of preproduction artifacts, **do not** provide download links to 'repository.apache.org' assets to users external to The ASF.
 
 If your Apache project would like to use `repository.apache.org`, see [Publishing Maven Releases](publishing-maven-artifacts.html).
 


### PR DESCRIPTION
based on conversation with @fluxo, updated the page to make clear that repo.a.o is primarily for internal ASF use.

Removed one FAQ item that repeated material now in the 'basic information' section.