### PR TITLE
added the correct link for creating jira project to render

### DIFF
--- a/content/pages/infra-contact.md
+++ b/content/pages/infra-contact.md
@@ -167,7 +167,7 @@ That depends on your role and what you want to do. If this chart doesn't help, I
   <tr valign="top" style="border: 1px solid">
     <td style="padding:10px;border: 1px solid">create a <b>Jira project</b></td>
     <td style="padding:10px;border: 1px solid">Key name (e.g., INFRA), Jira user names of 1-2 project members who will be project admins, mailing list address to which Jira notifications should go</td>
-    <td style="padding:10px;border: 1px solid">Go to <a href="https://selfserve.apache.org/confluence.html" target="_blank">Self-serve</a> and follow the prompts</td>
+    <td style="padding:10px;border: 1px solid">Go to <a href="https://selfserve.apache.org/jira-project.html" target="_blank">Self-serve</a> and follow the prompts</td>
   </tr>
   <tr valign="top"style="border: 1px solid">
     <td style="padding:10px;border: 1px solid"><b>migrate</b> your project's SVN repository to Git</td>


### PR DESCRIPTION
Fixes: #147 

Added the exact link of the page for creating jira project instead of given invalid link to render same as expected behavior as given below

[expected_behavior.webm](https://github.com/apache/infrastructure-website/assets/107138786/0469afed-452b-4105-8808-adf7cd93ba58)
