### PR TITLE
Removed Invalid Link from the subversion basics and added the expected link which will redirect to the subversion basics page

### DIFF
--- a/content/pages/patch.md
+++ b/content/pages/patch.md
@@ -4,7 +4,7 @@ To contribute a change or addition to existing source code:
 
 ### Using Subversion ###
 
-See [Subversion basics](subversion-basics.html)
+See [Subversion basics](svn-basics.html)
 
 1. Check out the latest copy of the source code from the project's code repository.
 2. Change the source files to incorporate your change or addition. Make sure you provide appropriate source code documentation (like javadoc for


### PR DESCRIPTION
Fixes : [ #153 ]

**Changes**
I Removed Invalid Link from the subversion basics of [patch page] and added the expected link in it's place which will redirect to the subversion basics page as shown below

![Screenshot 2024-01-27 010717](https://github.com/apache/infrastructure-website/assets/107138786/9d999fbd-d282-4e63-8bb9-38662a35a10c)

