### PR TITLE
Update github-actions-secrets.md added example per issue 198

### DIFF
--- a/content/pages/github-actions-secrets.md
+++ b/content/pages/github-actions-secrets.md
@@ -7,7 +7,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 ***A note on testing***: Some projects would like to use GitHub Actions for complex processes, such as automating their tests of software builds. 
 
-The _time_ runners are in use (measured in minutes) is unlimited for public repositories so how long a test takes isn't the issue. The issue is tying up limited 'runners' (nodes) while those minutes are running. Apache has 180 runners for over 1200 repositories, so the concern would be how many runners the test requires, which are then unavailable to other projects for the duration of the test. Out of those 180 runners, only 50 Mac OS runners can be in use at one time for all ASF projects.
+The _time_ runners are in use (measured in minutes) is unlimited for public repositories so how long a test takes isn't the issue. The issue is tying up limited 'runners' (nodes) while those minutes are running. Apache has a limited number of runners for over 1200 repositories, so the concern would be how many runners the test requires, which are then unavailable to other projects for the duration of the test.
 
 The ASF maxes out its runner allocation quite often, so a project needs to plan carefully to make best use of them for everyone's sake. For example, it would be important not to trigger a full release test with a pull request that is correcting a typo on one page in one module.
 

--- a/content/pages/github-actions-secrets.md
+++ b/content/pages/github-actions-secrets.md
@@ -25,14 +25,14 @@ A **GitHub <a href="https://docs.github.com/en/developers/apps/about-apps#person
 
 See <a href="https://cwiki.apache.org/confluence/display/INFRA/Github+Secrets+and+Tokens" target="_blank">GitHub secrets and tokens</a>.
 
-### Examples ###
+### Examples
 
-#### GitHub Secrets ####
+#### GitHub Secrets
 
 <a href="https://arrow.apache.org/" target="_blank">Apache Arrow</a> has GitHub Secrets added to their Arrow GitHub repos with the name 'DOCKERHUB_USER' and token 'DOCKERHUB_TOKEN' created as the user account on DockerHub (those account details are in LP).
 Additionally, in DockerHub, an 'arrow-dev' repository was created and the DockerHub 'jenkins' team (containing  the DockerHub 'DOCKERHUB_USER' user) was given admin access.
 
-#### GitHub Actions ####
+#### GitHub Actions
 
 Using Apache Arrow again as an example, the tokens above can be called using this code:
 
@@ -42,3 +42,20 @@ docker login -u ${{ secrets.DOCKERHUB_USER }} \
 -p ${{ secrets.DOCKERHUB_TOKEN }}
 docker-compose push ...
 ```
+
+#### Using an argument to extend the validity of a token for Develocity
+
+If you use the `setup-gradle` Action, it creates a short-lived Develocity token, which expires by default after two hours. If your build takes longer than two hours to run, the token becomes invalid and the build fails.
+
+To extend the validity of the token, adjust the `develocity-token-expiry` action parameter:
+
+```
+ develocity-token-expiry:
+    description: The Develocity short-lived access tokens expiry in hours. Default is 2 hours.
+    required: false
+```
+
+Further information is at these pages: 
+
+  - <a href="https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#managing-develocity-access-keys" target="_blank">Managing Develocity access keys</a>
+  - <a href="https://docs.gradle.com/develocity/gradle-plugin/current/#short_lived_access_tokens" target="_blank">Short-lived access tokens</a>


### PR DESCRIPTION
example for extending the validity of a Develocity short-lived token.