### PR TITLE
Fix typo in href

### DIFF
--- a/content/pages/asf-pelican-config.md
+++ b/content/pages/asf-pelican-config.md
@@ -4,7 +4,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 **Note**
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 This page was relevant to ASF-Pelican, but is **not relevant** to the replacement Pelican GitHub Action.
 


### PR DESCRIPTION
The colon was on the wrong side of the slashes