### PR TITLE
Fix typo in URL

### DIFF
--- a/content/pages/asf-pelican-branches.md
+++ b/content/pages/asf-pelican-branches.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 The material below is **relevant** to the older Pelican build system and the Pelican GitHub Action.
 

--- a/content/pages/asf-pelican-build.md
+++ b/content/pages/asf-pelican-build.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 For websites using the ASf-Pelican template, configure the build using the `pelicanconf.py` settings.
 

--- a/content/pages/asf-pelican-data.md
+++ b/content/pages/asf-pelican-data.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 The material below is **relevant** to the older Pelican build system and the Pelican GitHub Action.
 

--- a/content/pages/asf-pelican-gettingstarted.md
+++ b/content/pages/asf-pelican-gettingstarted.md
@@ -3,7 +3,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 The material below relates to the 2019 ASF-Pelican and is **not relevant** to the Pelican GitHub Action.
 

--- a/content/pages/asf-pelican-plugins.md
+++ b/content/pages/asf-pelican-plugins.md
@@ -4,7 +4,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 **Note**
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 The following material is correct for both ASF-Pelican and its replacement.
 

--- a/content/pages/asf-pelican-theme.md
+++ b/content/pages/asf-pelican-theme.md
@@ -4,7 +4,7 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 **Note**
 In 2019 Infra created ASF-Pelican as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 The following material is correct for both ASF-Pelican and its replacement.
 <hr/>

--- a/content/pages/website-guidelines.md
+++ b/content/pages/website-guidelines.md
@@ -18,6 +18,6 @@ These guidelines relate to Infra policies on resource consumption, linking, lega
 - All web sites must be available on ASF's git or svn servers, and published using git- or pypubsub.
 - Do not host source releases or convenience binaries directly on the web site. See [Release download pages for projects](release-download-pages.html).
 
-**Note**: Any ASF project can use the ASF **Infrastructure Pelican Action** GitHub Action to compile and deploy its website. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>. 
+**Note**: Any ASF project can use the ASF **Infrastructure Pelican Action** GitHub Action to compile and deploy its website. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>. 
 
 Should you have any questions, feel free to contact us at <a href="mailto:infrastructure@apache.org" target="_blank">infrastructure@apache.org</a> or on our <a href="https://the-asf.slack.com" target="_blank">Slack channel</a>.


### PR DESCRIPTION
Seems like a copy and paste error, where the colon was placed on the wrong side of the slashes.