### PR TITLE
dmarc: document status quo

### DIFF
--- a/content/blog/dmarc_filtering_on_lists_that.md
+++ b/content/blog/dmarc_filtering_on_lists_that.md
@@ -1,13 +1,22 @@
 title: DMARC filtering on lists that munge messages
-date: '2014-06-03T21:57:08+00:00'
+date: '2025-11-21T17:12:45+00:00'
 permalink: dmarc_filtering_on_lists_that
 layout: post
 
-<hr/>
-**Note**: The solution described below has been incorporated into ezmlm. However, it creates a new problem, generating double 'Reply-To:' headers in the case of lists with a `reply-to` set to something other than the list name. A complete rewrite of this function is under consideration. You can follow the discussion on Jira ticket <a href="https://issues.apache.org/jira/browse/INFRA-24849" target="_blank">INFRA-24849</a>.
-<hr/>
+<p>In the battle against spam, it is increasingly common for senders to
+attach a DKIM signature to their emails, and instruct recipients to
+validate those. This presents a challenge for mailinglists, which often
+do some form of message munging, whether it be adding Subject header prefixes,
+a Reply-To header, appending message trailers, or removing mime components.</p>
 
-<p>Since Yahoo! switched their DMARC policy in mid-April, we've seen an increase in undeliverable messages sent from our mail server for Yahoo! accounts subscribed to our lists. &nbsp; Roughly half of Apache's mailing lists do some form of message munging, whether it be Subject header prefixes, appended message trailers, or removed mime components. &nbsp;Such actions are incompatible with Y!'s policy for its users, which has meant more bounces and more frustration trying to maintain inclusive discussions with Y! users.</p> 
-  <p>Since Y!'s actions are likely just the beginning of a trend towards strong DMARC policies aimed at eliminating forged emails, we've taken the extraordinary step of munging Y! user's From headers to append a spec-compliant .INVALID marker on their address, and dropping the DKIM-Signature: header for such messages. &nbsp;We are an ezmlm shop and maintain a heavily customized .ezmlmrc file, so carrying this action out was relatively straightforward with a 30-line perl header filter prepended to certain lines in the &quot;editor&quot; block of our .ezmlmrc file. &nbsp;The filter does a dynamic lookup of DMARC &quot;p=reject&quot; policies to inform its actions, so we are prepared for future adopters beyond the early ones like Yahoo!, AOL, Facebook, LinkedIn, and Twitter. &nbsp; Interested parties in our solution may visit <a href="http://www.sunstarsys.com/essays/mailing-lists">this page</a> for details and the Apache-licensed code.</p> 
-  <p>Of course this filter only applies to half our lists- the remainder that do no munging are perfectly compatible with DMARC rejection policies without modification of our list software or configuration. &nbsp;Apache projects that prefer to avoid munging may file a Jira ticket with infrastructure to ask that their lists be set to &quot;ezmlm-make -+ -TXF&quot; options.</p> 
-  <p> </p>
+<p>When the sender has set a 'reject policy' on their domain, we now replace
+the sender with `John Doe via somelist <somelist@lists.apache.org>`, so that
+the sender domain will be apache.org and the original senders' policy does
+not come into play.</p>
+
+<p>This replaces an ASF-specific filter that could be configured for ASF lists
+since 2014. This previous filter would replace the sender with something like
+`John Doe <john@doe.com.INVALID>`. This approach broke deliverability of some
+emails when large providers such as GMail and Outlook made their rules around
+duplicate `Reply-To` and `Cc` headers more strict, introducing the need to
+build this into ezmlm itself rather than in a separate filter.</p>


### PR DESCRIPTION
More details on the exact background have been shared on the committers list at https://lists.apache.org/thread/w9gqyl4pb38oslzxsgkytgcng60o8o8k this text focuses more on the status quo than on the delta between the old situation. We might even remove that last paragraph to make it even more to-the-point.