### PR TITLE
Clarify automated release signing

### DIFF
--- a/content/pages/release-signing.md
+++ b/content/pages/release-signing.md
@@ -695,7 +695,7 @@ Projects may make use of automated signing for artifacts built by a CI system su
 
 - All artifacts being signed can be built <a href="https://reproducible-builds.org" target="_blank">reproducibly</a>
 - CI deploys the artifacts to a staging environment
-- The release procedure contains a validation step where all artifacts are reproduced on <a href="https://www.apache.org/legal/release-policy.html#owned-controlled-hardware" target="_blank">trusted hardware</a> (i.e. not GitHub Actions) before publication to pages intended for end users. This means rebuilding the artifacts from source and validating the resulting artifacts are bit-by-bit identical to those staged for release.
+- The release process contains a validation step where all artifacts are reproduced and validated on <a href="https://www.apache.org/legal/release-policy.html#owned-controlled-hardware" target="_blank">trusted hardware</a> (i.e. not GitHub Actions) before publication to pages intended for end users. This means rebuilding the artifacts from source and validating the resulting artifacts are bit-by-bit identical to those staged for release.
 
 The Apache Security Team should be notified of any pending requests for CI signing keys, and should approve the workflow before it is being put into use. In this request, please highlight the intended change to your release process where you make sure artifacts are validated on trusted hardware before release.
 See <a href="https://issues.apache.org/jira/browse/INFRA-23996" target="_blank">INFRA-23996</a> for background on this.


### PR DESCRIPTION
Projects still commonly misunderstand that GitHub Actions does not count as 'trusted hardware', or don't share a link to the proposed change to their release process in their initial request. Perhaps this will make it clearer?