### PR TITLE
Docs: List default allowed domains in CSP builder (#247)

### DIFF
--- a/content/pages/tools/csp.md
+++ b/content/pages/tools/csp.md
@@ -27,6 +27,13 @@ SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ htt
 Any hosts listed in the `CSP_PROJECT_DOMAINS` variable will be added to the default- and base source 
 elements in the existing CSP header, and should suffice for the vast majority of projects.
 
+The following domains are already allowed by default and do not need to be added:
+* `https://www.apachecon.com/`
+* `https://www.communityovercode.org/`
+* `https://*.apache.org/`
+* `https://apache.org/`
+* `https://*.scarf.sh/`
+
 If you need more specifically tailored headers, please reach out to users@infra.apache.org 
 and we can assist you.
 


### PR DESCRIPTION
## Description
This PR updates the CSP (Content Security Policy) builder documentation to list the domains that are already allowed by default. 

As noted in issue #247, the current documentation explains how to add new domains but doesn't clarify which ones are already whitelisted globally by Apache Infrastructure. Adding this list helps project maintainers determine if they actually need to request additional approvals or manual configurations.

## Changes
- Listed the following default domains to `csp.md`:
    - https://www.apachecon.com/
    - https://www.communityovercode.org/
    - https://*.apache.org/
    - https://apache.org/
    - https://*.scarf.sh/

Fixes #247