### PR TITLE
Make navbar sticky using Bootstrap sticky-top for improved usability

### DIFF
--- a/content/theme/templates/menu.html
+++ b/content/theme/templates/menu.html
@@ -1,5 +1,5 @@
 <!-- nav bar -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark" aria-label="Fifth navbar example">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top" aria-label="Fifth navbar example">
     <div class="container-fluid">
         <a class="navbar-brand" href="/"><img src="https://apache.org/images/feather.png" style="height: 32px;"/> Apache Infrastructure</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarADP" aria-controls="navbarADP" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
**Problem**
The navigation bar disappears when scrolling down long pages, making navigation inconvenient.

**Solution**
Added Bootstrap's `sticky-top` class to the shared `menu.html` template so the navbar remains visible while scrolling.

**Impact**
- Improves usability across all pages
- Uses existing Bootstrap utility (no additional CSS required)
- Minimal and safe change

_Closes <271>_