### PR TITLE
Update wiki OPIE link

### DIFF
--- a/content/pages/doc.md
+++ b/content/pages/doc.md
@@ -60,7 +60,7 @@ lookup for Apache Committers.
 - <a href="https://whimsy.apache.org/" target="_blank">The Whimsy Project</a> provides a number of committer-specific tools for finding information about Apache people.
 - [Transitioning to a new PGP key](key-transition.html)
 - [Getting started with Git](git-primer.html)
-- Information on setting up and using <a href="https://cwiki.apache.org/confluence/display/INFRA/OPIE" target="_blank">OPIE (One Password In Everything)</a>.
+- Information on setting up and using <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=122916896" target="_blank">OPIE (One Password In Everything)</a>.
 - The ASF has a fee-waiver arrangement so that committers participating in ASF projects can make free use of the [Apple Developer Program](apple-dev-program.html) to prepare and distribute project applications for Apple operating systems.
 - [Apache mailing list etiquette](contrib-email-tips.html)
 - [How to submit a patch for project code](patch.html)


### PR DESCRIPTION
The existing link is 404, probably because of the addition of "/ Orthrus" in the title.