### PR TITLE
pin apache/infrastructure-actions/pelican to 93dfe4693bc118397840e7e4ae447e57a3eea7ee

### DIFF
--- a/.github/workflows/build-pelican.yml
+++ b/.github/workflows/build-pelican.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: 'master'
-      - uses: apache/infrastructure-actions/pelican@main
+      - uses: apache/infrastructure-actions/pelican@93dfe4693bc118397840e7e4ae447e57a3eea7ee # main
         with:
           destination: 'asf-site'
           gfm: 'true'


### PR DESCRIPTION
Update Pelican action to a specific commit hash.

as recommended by ASF Infra https://lists.apache.org/thread/zd9cpkhwt0xh2sq958gwc62cw4f86yc7