### PR TITLE
Fix typos and grammar in services and documentation pages

### DIFF
--- a/content/pages/doc.md
+++ b/content/pages/doc.md
@@ -1,7 +1,7 @@
 Title: Documentation
 license: https://www.apache.org/licenses/LICENSE-2.0
 
-Infra provides a library of resources that are constantly evolving to reflect the current state of Apache's infrastructure and policies.
+Infra provides a library of resources that is constantly evolving to reflect the current state of Apache's infrastructure and policies.
 
 ### Overview ###
 

--- a/content/pages/doc.md
+++ b/content/pages/doc.md
@@ -1,7 +1,7 @@
 Title: Documentation
 license: https://www.apache.org/licenses/LICENSE-2.0
 
-Infra provides a library of resources that is constantly evolving to reflect the current state of Apache's infrastructure and policies.
+Infra provides a library of resources that are constantly evolving to reflect the current state of Apache's infrastructure and policies.
 
 ### Overview ###
 
@@ -11,7 +11,7 @@ Infra provides a library of resources that is constantly evolving to reflect the
 
 ### General guides ###
 
-- [Understanding Opensource](understanding-opensource.html)
+- [Understanding Open source](understanding-opensource.html)
 - [Writing a good bug report](bug-writing-guide.html)
 - [Creating a Jira ticket](jira-guidelines.html)
 - [Creating a patch for project code](patch.html)

--- a/content/pages/services.md
+++ b/content/pages/services.md
@@ -1,4 +1,4 @@
-Title: Services and Tools
+Title: 
 license: https://www.apache.org/licenses/LICENSE-2.0
 
 **Note**: If you cannot access one or more ASF repositories or services, your IP address may have been **blocked**. Before contacting Infra, review <a href="https://infra.apache.org/abc/" target="_blank">Abuse and Connectivity Issues at the ASF</a> (ABC). The page lists the common overuse (or abuse) issues that affect our site's work and cause an automatic IP address block, and recommends steps to get such a block removed. ABC also provides a channel to contact Infra if you need more information than the page provides.
@@ -26,7 +26,7 @@ Infra maintains a wide range of tools for PMCs, project committers, and the Apac
     - <a href="#code-dist">Code distribution</a>
     - <a href="#virtual-servers">Virtual servers</a>
     - <a href="#voting">Online voting</a>
-    - **Visual Studio**: The ASF has a presence in the <a href="https://marketplace.visualstudio.com/publishers/ASF" target="_blank">Visual Studio Marketplace</a>. Several projects have posted extensions there to make it easier for their developers to work in VS on their product's code. Projects which would like to add their extensions to the Marketplace should make the request to Infra in a Jira ticket.
+    - **Visual Studio**: The ASF has a presence in the <a href="https://marketplace.visualstudio.com/publishers/ASF" target="_blank">Visual Studio Marketplace</a>. Several projects have posted extensions there to make it easier for their developers to work in VS on their product's code. Projects that would like to add their extensions to the Marketplace should make the request to Infra in a Jira ticket.
   - <a href="#other">Other tools</a>
     - <a href="#dns">DNS</a>
     - <a href="#url-shortener">URL shortener</a>
@@ -96,9 +96,9 @@ Infra supports an array of tools and services to help projects develop and suppo
 - Every project can use a dedicated space on the [Confluence wiki](cwiki.html).
   - How to <a href="https://cwiki.apache.org/confluence/display/INFRA/Managing+permissions+on+your+project%27s+Confluence+Space" target="_blank">manage user permissions</a> in your project's wiki space.
   - How to <a href="https://cwiki.apache.org/confluence/display/INFRA/Giving+a+user+edit+access+to+Confluence" target="_blank">give a user edit access</a> to the wiki space.
-- <a href="https://reporter.apache.org/" target="_blank">Reporter</a> provides actvitity statistics and other information about your project, and editing tools to help you write and submit your project's quarterly Board reports.
+- <a href="https://reporter.apache.org/" target="_blank">Reporter</a> provides activity statistics and other information about your project, and editing tools to help you write and submit your project's quarterly Board reports.
 - You can create and run a [project blog](project-blogs.html).
-- You can establish a [Slack channel](slack.html) for real-time team discussions. Once you have your Slack channel, Infra can set up a _Slack-Jira bridge_ so that you get notices in your channel of new or updated Jira tickets. open a Jira ticket for INFRA to get this feature for your TLP's Slack channel.
+- You can establish a [Slack channel](slack.html) for real-time team discussions. Once you have your Slack channel, Infra can set up a _Slack-Jira bridge_ so that you get notices in your channel of new or updated Jira tickets. Open a Jira ticket for INFRA to get this feature for your TLP's Slack channel.
 - Teams can conduct and record meetings through Internet Relay Chat (IRC) using [ASFBot](asfbot.html). However, you must conduct formal votes on decisions in the appropriate project email list, following the <a href="https://www.apache.org/foundation/voting.html" target="_blank">Apache voting process</a>.
 - [Localization tools](localization.html).
 - The Apache <a href="https://creadur.apache.org/rat/" target="_blank">Release Audit Tool (RAT)</a> can help you confirm that your proposed product release complies with all ASF requirements.

--- a/content/pages/services.md
+++ b/content/pages/services.md
@@ -1,4 +1,4 @@
-Title: 
+Title: Services and Tools
 license: https://www.apache.org/licenses/LICENSE-2.0
 
 **Note**: If you cannot access one or more ASF repositories or services, your IP address may have been **blocked**. Before contacting Infra, review <a href="https://infra.apache.org/abc/" target="_blank">Abuse and Connectivity Issues at the ASF</a> (ABC). The page lists the common overuse (or abuse) issues that affect our site's work and cause an automatic IP address block, and recommends steps to get such a block removed. ABC also provides a channel to contact Infra if you need more information than the page provides.


### PR DESCRIPTION
Fixes typos and minor grammar issues in the Services and Tools and Documentation pages.

Part of #285