### PR TITLE
Fix HTML consistency and link formatting in documentation and services pages

### DIFF
--- a/content/pages/doc.md
+++ b/content/pages/doc.md
@@ -27,7 +27,7 @@ Infra provides a library of resources that is constantly evolving to reflect the
 
 #### Build and release ####
 - [Release creation process](release-publishing.html)
-- Creating optional [Maven releases](publishing-maven-artifacts.html) 
+- Creating optional [Maven releases](publishing-maven-artifacts.html)
 - [Signing releases](release-signing.html)
 - [Cryptography with OpenPGP](openpgp.html)
 - [Release distribution policy](release-distribution.html)
@@ -55,8 +55,7 @@ Infra provides a library of resources that is constantly evolving to reflect the
 
 - [New committer's guide](new-committers-guide.html)
 - [Managing your Apache email address](committer-email.html)
-- <a href="https://people.apache.org" target="_blank">Apache People</a> provides a simple phone book-like 
-lookup for Apache Committers.
+- <a href="https://people.apache.org" target="_blank">Apache People</a> provides a simple phone book-like lookup for Apache Committers.
 - <a href="https://whimsy.apache.org/" target="_blank">The Whimsy Project</a> provides a number of committer-specific tools for finding information about Apache people.
 - [Transitioning to a new PGP key](key-transition.html)
 - [Getting started with Git](git-primer.html)

--- a/content/pages/services.md
+++ b/content/pages/services.md
@@ -38,7 +38,7 @@ Infra maintains a wide range of tools for PMCs, project committers, and the Apac
 <h3 id="web-sites">Websites<a class="headerlink" href="#web-sites" title="Permanent link">&para;</a></h3>
 
   - <a href="https://apache.org">`www.apache.org`</a> is the main ASF website.
-  - <a href="https://apache.org/dev/#web" targety="_blank">ASF project websites</a>.
+  - <a href="https://apache.org/dev/#web" target="_blank">ASF project websites</a>.
   - <a href="https://infra-reports.apache.org/site-source/">ASF project website sources</a>
   - An index of <a href="https://projects.apache.org/projects.html?name" target="_blank">all ASF projects</a> (if they have set up a DOAP).
   - Any ASF project can use the [ASF-Pelican template](asf-pelican.html) as the basis for their project website.
@@ -76,7 +76,7 @@ People who are not part of the ASF community but wish to file a Jira ticket abou
 [ASF account management](account-mgmt.html) provides guidance if you want to update your account details, or have lost access to your account.
   
 <h3 id="notices">Getting notices of infrastructure events<a class="headerlink" href="#notices" title="Permanent link">&para;</a></h3>
-You can subscribe to notices of infrastructure events that you want to know about, ranging from Subversion commits to emails to specific lists. [Learn more here](pypubsub.html).
+You can subscribe to notices of infrastructure events that you want to know about, ranging from Subversion commits to emails to specific lists. <a href="pypubsub.html">Learn more here</a>.
 
 <h3 id="ldap">LDAP-enabled services<a class="headerlink" href="#ldap" title="Permanent link">&para;</a></h3>
 
@@ -218,9 +218,9 @@ Infra manages the ASF DNS, which is registered with Namecheap.
 
 <a href="https://s.apache.org" target="_blank">URL shortener</a>
 
-<h3 id="sharing">Infra Reporting Dashboard<a class="headerlink" href="#infra-reports" title="Permanent link">&para;</a></h3>
+<h3 id="infra-reports">Infra Reporting Dashboard<a class="headerlink" href="#infra-reports" title="Permanent link">&para;</a></h3>
 
-The <a href="https://infra.apache.org/infra-reports.html" target="_blank">ASF Infrastructure Reporting Dashboard</a> contains a collection of reports on the overall health and activity of the infrastructure at the ASF. Some reports are available only for ASF Members and Infra team members.
+The <a href="https://`infra.apache.org`/infra-reports.html" target="_blank">ASF Infrastructure Reporting Dashboard</a> contains a collection of reports on the overall health and activity of the infrastructure at the ASF. Some reports are available only for ASF Members and Infra team members.
 
 <h3 id="machines">Machine list<a class="headerlink" href="#machines" title="Permanent link">&para;</a></h3>
 

--- a/content/pages/services.md
+++ b/content/pages/services.md
@@ -76,7 +76,7 @@ People who are not part of the ASF community but wish to file a Jira ticket abou
 [ASF account management](account-mgmt.html) provides guidance if you want to update your account details, or have lost access to your account.
   
 <h3 id="notices">Getting notices of infrastructure events<a class="headerlink" href="#notices" title="Permanent link">&para;</a></h3>
-You can subscribe to notices of infrastructure events that you want to know about, ranging from Subversion commits to emails to specific lists. <a href="pypubsub.html">Learn more here</a>.
+You can subscribe to notices of infrastructure events that you want to know about, ranging from Subversion commits to emails to specific lists. [Learn more here](pypubsub.html).
 
 <h3 id="ldap">LDAP-enabled services<a class="headerlink" href="#ldap" title="Permanent link">&para;</a></h3>
 
@@ -218,9 +218,9 @@ Infra manages the ASF DNS, which is registered with Namecheap.
 
 <a href="https://s.apache.org" target="_blank">URL shortener</a>
 
-<h3 id="infra-reports">Infra Reporting Dashboard<a class="headerlink" href="#infra-reports" title="Permanent link">&para;</a></h3>
+<h3 id="sharing">Infra Reporting Dashboard<a class="headerlink" href="#infra-reports" title="Permanent link">&para;</a></h3>
 
-The <a href="https://`infra.apache.org`/infra-reports.html" target="_blank">ASF Infrastructure Reporting Dashboard</a> contains a collection of reports on the overall health and activity of the infrastructure at the ASF. Some reports are available only for ASF Members and Infra team members.
+The <a href="https://infra.apache.org/infra-reports.html" target="_blank">ASF Infrastructure Reporting Dashboard</a> contains a collection of reports on the overall health and activity of the infrastructure at the ASF. Some reports are available only for ASF Members and Infra team members.
 
 <h3 id="machines">Machine list<a class="headerlink" href="#machines" title="Permanent link">&para;</a></h3>
 

--- a/content/theme/templates/frontpage.html
+++ b/content/theme/templates/frontpage.html
@@ -102,7 +102,7 @@
                                 <a href="/roundtable.html">Roundtables</a>
                             </h5>
                             <p class="card-text">
-                                Infra holds Roundtable meetings most months to discuss infrastructure development and challenges. Participants are welcome to bring their own concerns, questions, and suggestions. Information about how to take part is here: <a href="https://infra.apache.org/roundtable>infra.apache.org/roundtable</a></p>
+                                Infra holds Roundtable meetings most months to discuss infrastructure development and challenges. Participants are welcome to bring their own concerns, questions, and suggestions. Information about how to take part is here: <a href="https://infra.apache.org/roundtable">infra.apache.org/roundtable</a></p>
                         <p>The next Infra roundtable will be on the #roundtable Slack channel on <b>Wednesday, May 6, 2026, 1700 UTC</b>. The featured topic:  <b>AI coding: implications for ASF infrastructure</b>.</p>
                             <div class="d-grid mt-auto">
                                 <a href="/roundtable.html" class="btn btn-primary">Learn More...</a>


### PR DESCRIPTION
This PR improves HTML consistency and link formatting across the documentation and services pages.

Changes include:
- Fixing minor HTML inconsistencies 
- Standardizing link formatting for better readability and maintainability
- Cleaning up minor formatting issues without altering functionality.

Part of #285 