### PR TITLE
Fix typos and grammatical errors in documentation files

### DIFF
--- a/content/pages/infra-news.md
+++ b/content/pages/infra-news.md
@@ -11,4 +11,4 @@ license: https://www.apache.org/licenses/LICENSE-2.0
 
 The Maven team is working on a resolution to this issue. Until the fix is available, they suggest **disabling parallel PUTs**.
 
-For details on disabling parallel PUTs, and what to do if you have already run into this problem in a build, see this article in the Infra blog: <a href="https://infra.apache.org/blog/parallelputissue.html">Parallel PUT problem in repository.apache.org with Apache Maven 3.9.12]</a>. 
+For details on disabling parallel PUTs, and what to do if you have already run into this problem in a build, see this article in the Infra blog: <a href="https://infra.apache.org/blog/parallelputissue.html">Parallel PUT problem in repository.apache.org with Apache Maven 3.9.12</a>. 

--- a/content/pages/roundtable.md
+++ b/content/pages/roundtable.md
@@ -21,9 +21,9 @@ During the roundtable, people can either **speak or type** their comments. If yo
 
 ### Once you have joined #roundtable ###
 
-`#roundtable` is now in your list of channels. In the future, you will can just click on its link rather than asking to join it again.
+`#roundtable` is now in your list of channels. In the future, you can just click on its link rather than asking to join it again.
 
-When you are in the channel, you can share messages with others as a sort of pre-meeting. At some point an infra staffer will post a message inviting people to join the channel **huddle**. Click the link to join the huddle, an icon that looks like the outline of a headset.
+When you are in the channel, you can share messages with others as a sort of pre-meeting. At some point an Infra staffer will post a message inviting people to join the channel **huddle**. Click the link to join the huddle, an icon that looks like the outline of a headset.
 
 ### What happens in the roundtable
 


### PR DESCRIPTION
Fixes minor grammar errors in the roundtable documentation page and a formatting issue in a link where an extra closing bracket was present in the link text.

No functional changes.

Part of #285 