### PR TITLE
chore: add alt text to logo and aria-label to search

### DIFF
--- a/content/theme/templates/menu.html
+++ b/content/theme/templates/menu.html
@@ -1,7 +1,7 @@
 <!-- nav bar -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top" aria-label="Fifth navbar example">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/"><img src="https://apache.org/images/feather.png" style="height: 32px;" alt="Apache Feather Logo"/> Apache Infrastructure</a>
+        <a class="navbar-brand" href="/"><img src="https://apache.org/images/feather.png" style="height: 32px;" alt="Apache Software Foundation oak leaf logo"/> Apache Infrastructure</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarADP" aria-controls="navbarADP" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/content/theme/templates/menu.html
+++ b/content/theme/templates/menu.html
@@ -1,7 +1,7 @@
 <!-- nav bar -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top" aria-label="Fifth navbar example">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/"><img src="https://apache.org/images/feather.png" style="height: 32px;"/> Apache Infrastructure</a>
+        <a class="navbar-brand" href="/"><img src="https://apache.org/images/feather.png" style="height: 32px;" alt="Apache Feather Logo"/> Apache Infrastructure</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarADP" aria-controls="navbarADP" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -52,7 +52,7 @@
                     <a class="nav-link" href="/contact.html">Contact Us</a>
                 </li>
                 <li class="nav-item dropdown">
-                    <a href="#" class="nav-link dropdown-toggle hidden-xs" data-bs-toggle="dropdown">
+                    <a href="#" class="nav-link dropdown-toggle d-none d-sm-inline-block" data-bs-toggle="dropdown" aria-label="Search">
                         <span class="fa-solid fa-magnifying-glass" aria-hidden="true"></span> Search</a>
                     <ul class="search-form dropdown-menu">
                         <li>


### PR DESCRIPTION
Improved header accessibility for screen readers.

Changes
Added alt text to the Apache logo.
Added aria-label to the Search toggle.
Updated search visibility classes for Bootstrap 5 compatibility.

Closes #290 